### PR TITLE
Reduce the default security level for openssl

### DIFF
--- a/openssl-conf.cnf
+++ b/openssl-conf.cnf
@@ -7,5 +7,5 @@ ssl_conf = ssl_sect
 system_default = system_default_sect
 
 [system_default_sect]
-CipherString = DEFAULT@SECLEVEL=1
+CipherString = DEFAULT@SECLEVEL=0
 Options = UnsafeLegacyRenegotiation


### PR DESCRIPTION
Faced a similar issue to #3 when trying to run the console script.
```
curl: (35) OpenSSL/3.3.0: error:0A000102:SSL routines::unsupported protocol
Failed to retrieve key. Wrong password or banned?
```
Fixed with setting the default security level to 0.

According to `man 3 SSL_CTX_set_security_level` level 0 is
> Everything  is  permitted.  This  retains  compatibility with previous versions of OpenSSL.

Tested on
```
$ uname -a
Linux Mercury 6.9.2-arch1-1 #1 SMP PREEMPT_DYNAMIC Sun, 26 May 2024 01:30:29 +0000 x86_64 GNU/Linux
```

OpenSSL version:
```
$ openssl --version
OpenSSL 3.3.0 9 Apr 2024 (Library: OpenSSL 3.3.0 9 Apr 2024)
```

Closes #3